### PR TITLE
Added dtgov-ui to the approved issuer list for saml auth

### DIFF
--- a/overlord-commons-dev/src/main/java/org/overlord/commons/dev/server/discovery/WebAppModuleFromIDEDiscoveryStrategy.java
+++ b/overlord-commons-dev/src/main/java/org/overlord/commons/dev/server/discovery/WebAppModuleFromIDEDiscoveryStrategy.java
@@ -69,6 +69,14 @@ public class WebAppModuleFromIDEDiscoveryStrategy extends AbstractModuleDiscover
                 module.setInIDE(true);
                 module.setModuleDir(new File(pathToWebApp));
                 return module;
+            } else if (path.contains("/target/classes/")) {
+                String pathToWebApp = path.substring(0, path.indexOf("/target/classes/")) + "/src/main/webapp";
+                debug("Path to web app: " + pathToWebApp);
+
+                DevServerModule module = new DevServerModule();
+                module.setInIDE(true);
+                module.setModuleDir(new File(pathToWebApp));
+                return module;
             }
         }
 

--- a/overlord-commons-installer/src/main/resources/build.xml
+++ b/overlord-commons-installer/src/main/resources/build.xml
@@ -21,7 +21,7 @@
     <echo message="#                                                     #" />
     <echo message="# When calling, you can pass these properties:        #" />
     <echo message="#    overlord-commons.version:  Overlord Commons ver. #" />
-    <echo message="#    dist.dir:  location of JBoss EAP 6.1         #" />
+    <echo message="#    dist.dir:  location of JBoss EAP 6.1             #" />
     <echo message="#######################################################" />
 
     <antcall target="install-overlord-commons" />

--- a/overlord-commons-installer/src/main/resources/xslt/addSecurityDomains-jbossas7.xslt
+++ b/overlord-commons-installer/src/main/resources/xslt/addSecurityDomains-jbossas7.xslt
@@ -24,7 +24,7 @@
       <security-domain name="overlord-jaxrs" cache-type="default">
         <authentication>
           <login-module code="org.overlord.commons.auth.jboss7.SAMLBearerTokenLoginModule" flag="sufficient">
-            <module-option name="allowedIssuers" value="/s-ramp-ui,/s-ramp-governance" />
+            <module-option name="allowedIssuers" value="/s-ramp-ui,/s-ramp-governance,/dtgov-ui" />
           </login-module>
           <login-module code="UsersRoles" flag="sufficient">
             <module-option name="usersProperties" value="${{jboss.server.config.dir}}/overlord-idp-users.properties" />

--- a/overlord-commons-installer/src/main/resources/xslt/addSecurityDomains.xslt
+++ b/overlord-commons-installer/src/main/resources/xslt/addSecurityDomains.xslt
@@ -24,7 +24,7 @@
       <security-domain name="overlord-jaxrs" cache-type="default">
         <authentication>
           <login-module code="org.overlord.commons.auth.jboss7.SAMLBearerTokenLoginModule" flag="sufficient">
-            <module-option name="allowedIssuers" value="/s-ramp-ui,/s-ramp-governance" />
+            <module-option name="allowedIssuers" value="/s-ramp-ui,/s-ramp-governance,/dtgov-ui" />
           </login-module>
           <login-module code="UsersRoles" flag="sufficient">
             <module-option name="usersProperties" value="${{jboss.server.config.dir}}/overlord-idp-users.properties" />


### PR DESCRIPTION
This allows dtgov-ui to make saml bearer token authenticated calls to any of the REST services protected by the overlord-jaxrs security domain.
