### PR TITLE
Include apache commons logging dependency, as apache commons config seem...

### DIFF
--- a/overlord-commons-config/pom.xml
+++ b/overlord-commons-config/pom.xml
@@ -22,6 +22,10 @@
       <artifactId>commons-configuration</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
...s to be dependent upon it.

Found the problem when refactoring rtgov property management - not sure why it doesn't show up as a dependency on the apache commons config artifact. Note: Haven't added it to the list of packages in the bundle.
