### PR TITLE
Add back the export packages

### DIFF
--- a/overlord-commons-auth/pom.xml
+++ b/overlord-commons-auth/pom.xml
@@ -55,30 +55,10 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Name>${project.name}</Bundle-Name>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <!-- <Export-Package>
+            <Export-Package>
               org.overlord.commons.auth.util,
               org.overlord.commons.auth.filters
             </Export-Package>
-            <Import-Package>
-              javax.security.auth,
-              javax.security.auth.callback,
-              javax.security.auth.login,
-              javax.servlet,
-              javax.servlet.http,
-              javax.xml.datatype,
-              javax.xml.stream,
-              javax.xml.transform,
-              javax.xml.transform.dom,
-              org.picketlink.common.exceptions.exceptions,
-              org.picketlink.identity.federation.api.saml.v2.sig,
-              org.picketlink.identity.federation.core.parsers.saml,
-              org.picketlink.identity.federation.core.saml.v2.factories,
-              org.picketlink.identity.federation.core.saml.v2.util,
-              org.picketlink.identity.federation.saml.v2.assertion,
-              org.apache.commons.codec.binary,
-              org.overlord.commons.services,
-              org.w3c.dom
-            </Import-Package> -->
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
Required by the auth-jetty8 bundle when deployed in Karaf.
