### PR TITLE
[ENTESB-4353] Force unix-style line endings in checkstyle

### DIFF
--- a/overlord-commons-build/src/main/resources/checkstyle/checkstyle.xml
+++ b/overlord-commons-build/src/main/resources/checkstyle/checkstyle.xml
@@ -54,7 +54,10 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <!-- Force unix-style line separators -->
+        <property name="lineSeparator" value="lf"/>
+    </module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->


### PR DESCRIPTION
Force unix-style line endings in checkstyle.

Tested on ubuntu 14.04 and windows 2012 r2 with rtgov quickstarts and it seems to be working
